### PR TITLE
Only deploy to production on tagged versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+    tags: true


### PR DESCRIPTION
Instead of deploying on every commit that passes test cases, require a commit be tagged before release. This allows easier development in master and makes releases explicit but still fully automated.

It also means that every version running in production is associated with a tag and a version number. We can embed this version number somewhere subtle in the header so that it is immediately apparent which version a given screenshot from the wild was running against.

The new flow to release a version to production would be
```bash
# after committing the changes desired onto master...
npm version patch
git push origin master --tags
```

Discuss