### PR TITLE
Remove 3 minute time window

### DIFF
--- a/src/CanExplorer.js
+++ b/src/CanExplorer.js
@@ -56,6 +56,7 @@ export default class CanExplorer extends Component {
       lastBusTime: null,
       selectedMessage: null,
       currentParts: [0, 0],
+      currentWorkers: [],
       showOnboarding: false,
       showLoadDbc: false,
       showSaveDbc: false,
@@ -517,6 +518,7 @@ export default class CanExplorer extends Component {
   }, 500);
 
   onPartChange(part) {
+    console.log("Part change!");
     let { currentParts, canFrameOffset, route, messages } = this.state;
     if (canFrameOffset === -1 || part + PART_SEGMENT_LENGTH > route.proclog) {
       return;
@@ -541,10 +543,7 @@ export default class CanExplorer extends Component {
     messages = ObjectUtils.fromArray(messagesKvPairs);
 
     // update state then load new parts
-    this.setState(
-      { currentParts, messages, seekTime: part * 60 },
-      this.partChangeDebounced
-    );
+    this.setState({ currentParts, messages }, this.partChangeDebounced);
   }
 
   showEditMessageModal(msgKey) {
@@ -580,6 +579,14 @@ export default class CanExplorer extends Component {
 
   onSeek(seekIndex, seekTime) {
     this.setState({ seekIndex, seekTime });
+
+    let { currentParts } = this.state;
+    let currentPart = currentParts[0];
+    let part = Math.max(0, ~~(seekTime / 60) - 1);
+    console.log("Some shit? on seek yo, i think im in part", part);
+    if (part !== currentPart) {
+      this.onPartChange(part);
+    }
   }
 
   onUserSeek(seekTime) {
@@ -598,7 +605,7 @@ export default class CanExplorer extends Component {
       seekIndex = 0;
     }
 
-    this.setState({ seekIndex, seekTime });
+    this.onSeek(seekIndex, seekTime);
   }
 
   onMessageSelected(msgKey) {

--- a/src/CanExplorer.js
+++ b/src/CanExplorer.js
@@ -654,7 +654,7 @@ export default class CanExplorer extends Component {
 
     // update messages to only preserve entries in new part range
     let minTime = minPart * 60;
-    let maxTime = maxPart * 60;
+    let maxTime = maxPart * 60 + 60;
     Object.keys(messages).forEach(key => {
       let entries = messages[key].entries;
       let minIndex = 0;

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -469,22 +469,11 @@ export default class Explorer extends Component {
   }
 
   secondsLoaded() {
-    const message = this.props.messages[this.props.selectedMessage];
-    if (!message || message.entries.length === 0) {
-      return this.secondsLoadedRouteRelative(this.props.currentParts);
-    }
-
-    const { entries } = message;
-
-    const { segment } = this.state;
-    if (segment.length === 2) {
-      return segment[1] - segment[0];
-    } else {
-      return entries[entries.length - 1].time - entries[0].time;
-    }
+    return this.props.partsCount * 60;
   }
 
   startOffset() {
+    return 0;
     const partOffset = this.props.currentParts[0] * 60;
     const message = this.props.messages[this.props.selectedMessage];
     if (!message || message.entries.length === 0) {
@@ -663,6 +652,7 @@ export default class Explorer extends Component {
                 {this.timeWindow()}
                 <PartSelector
                   onPartChange={this.props.onPartChange}
+                  selectedPart={this.props.selectedPart}
                   partsCount={this.props.partsCount}
                 />
               </div>

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -409,7 +409,6 @@ export default class Explorer extends Component {
     const message = this.props.messages[this.props.selectedMessage];
     if (!message) {
       this.props.onUserSeek(time);
-      this.props.onSeek(0, time);
       return;
     }
 
@@ -648,14 +647,8 @@ export default class Explorer extends Component {
                 playSpeed={this.state.playSpeed}
                 onPlaySpeedChanged={this.changePlaySpeed}
               />
-              <div className="cabana-explorer-visuals-header">
-                {this.timeWindow()}
-                <PartSelector
-                  onPartChange={this.props.onPartChange}
-                  selectedPart={this.props.selectedPart}
-                  partsCount={this.props.partsCount}
-                />
-              </div>
+              <div className="cabana-explorer-visuals-header g-row" />
+              <br />
               <RouteVideoSync
                 message={this.props.messages[this.props.selectedMessage]}
                 secondsLoaded={this.secondsLoaded()}

--- a/src/components/HLS.js
+++ b/src/components/HLS.js
@@ -19,15 +19,6 @@ export default class HLS extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (
-      (nextProps.shouldRestart ||
-        nextProps.startTime !== this.props.startTime) &&
-      isFinite(nextProps.startTime)
-    ) {
-      this.videoElement.currentTime = nextProps.startTime;
-      this.props.onRestart();
-    }
-
     if (!this.videoElement.currentTime) {
       this.videoElement.currentTime = nextProps.startTime;
     }

--- a/src/components/HLS.js
+++ b/src/components/HLS.js
@@ -19,9 +19,6 @@ export default class HLS extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (!this.videoElement.currentTime) {
-      this.videoElement.currentTime = nextProps.startTime;
-    }
     this.videoElement.playbackRate = nextProps.playbackSpeed;
 
     if (nextProps.source !== this.props.source) {

--- a/src/components/PartSelector.js
+++ b/src/components/PartSelector.js
@@ -7,7 +7,8 @@ export default class PartSelector extends Component {
   static selectorWidth = 150;
   static propTypes = {
     onPartChange: PropTypes.func.isRequired,
-    partsCount: PropTypes.number.isRequired
+    partsCount: PropTypes.number.isRequired,
+    selectedPart: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -15,7 +16,6 @@ export default class PartSelector extends Component {
 
     this.state = {
       selectedPartStyle: this.makePartStyle(props.partsCount, 0),
-      selectedPart: 0,
       isDragging: false
     };
 
@@ -34,11 +34,12 @@ export default class PartSelector extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.partsCount !== this.props.partsCount) {
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.selectedPart !== this.props.selectedPart) {
+      console.log("updating styles for part picker");
       const selectedPartStyle = this.makePartStyle(
         nextProps.partsCount,
-        this.state.selectedPart
+        nextProps.selectedPart
       );
       this.setState({ selectedPartStyle });
     }
@@ -49,19 +50,15 @@ export default class PartSelector extends Component {
       0,
       Math.min(this.props.partsCount - PART_SEGMENT_LENGTH, part)
     );
-    if (part === this.state.selectedPart) {
+    if (part === this.props.selectedPart) {
       return;
     }
 
     this.props.onPartChange(part);
-    this.setState({
-      selectedPart: part,
-      selectedPartStyle: this.makePartStyle(this.props.partsCount, part)
-    });
   }
 
   selectNextPart() {
-    let { selectedPart } = this.state;
+    let { selectedPart } = this.props;
     selectedPart++;
     if (selectedPart + PART_SEGMENT_LENGTH >= this.props.partsCount) {
       return;
@@ -71,7 +68,7 @@ export default class PartSelector extends Component {
   }
 
   selectPrevPart() {
-    let { selectedPart } = this.state;
+    let { selectedPart } = this.props;
     selectedPart--;
     if (selectedPart < 0) {
       return;

--- a/src/components/RouteSeeker/RouteSeeker.js
+++ b/src/components/RouteSeeker/RouteSeeker.js
@@ -158,8 +158,8 @@ export default class RouteSeeker extends Component {
       return;
     }
 
-    const { currentTime } = videoElement;
-    let newRatio = this.props.segmentProgress(currentTime);
+    let { currentTime, duration } = videoElement;
+    let newRatio = currentTime / duration;
 
     if (newRatio === this.state.ratio) {
       this.playTimer = window.requestAnimationFrame(this.executePlayTimer);
@@ -168,6 +168,7 @@ export default class RouteSeeker extends Component {
 
     if (newRatio >= 1) {
       newRatio = 0;
+      currentTime = 0;
       this.props.onUserSeek(newRatio);
     }
 

--- a/src/components/RouteVideoSync.js
+++ b/src/components/RouteVideoSync.js
@@ -146,10 +146,7 @@ export default class RouteVideoSync extends Component {
 
     let { videoElement } = this.state;
     let seekTime = videoElement.duration * ratio;
-    console.log(videoElement.currentTime, seekTime, ratio);
-
     videoElement.currentTime = seekTime;
-    console.log("onUserSeek(ratio) {", seekTime);
 
     const funcSeekToRatio = () => this.props.onUserSeek(seekTime);
     if (ratio === 0) {

--- a/src/components/RouteVideoSync.js
+++ b/src/components/RouteVideoSync.js
@@ -145,11 +145,13 @@ export default class RouteVideoSync extends Component {
     /* ratio in [0,1] */
 
     let { videoElement } = this.state;
-    console.log(videoElement.currentTime);
     let seekTime = videoElement.duration * ratio;
-    videoElement.currentTime = seekTime;
+    console.log(videoElement.currentTime, seekTime, ratio);
 
-    const funcSeekToRatio = () => this.props.onUserSeek(this.ratioTime(ratio));
+    videoElement.currentTime = seekTime;
+    console.log("onUserSeek(ratio) {", seekTime);
+
+    const funcSeekToRatio = () => this.props.onUserSeek(seekTime);
     if (ratio === 0) {
       this.setState({ shouldRestartHls: true }, funcSeekToRatio);
     } else {

--- a/src/components/RouteVideoSync.js
+++ b/src/components/RouteVideoSync.js
@@ -144,6 +144,11 @@ export default class RouteVideoSync extends Component {
   onUserSeek(ratio) {
     /* ratio in [0,1] */
 
+    let { videoElement } = this.state;
+    console.log(videoElement.currentTime);
+    let seekTime = videoElement.duration * ratio;
+    videoElement.currentTime = seekTime;
+
     const funcSeekToRatio = () => this.props.onUserSeek(this.ratioTime(ratio));
     if (ratio === 0) {
       this.setState({ shouldRestartHls: true }, funcSeekToRatio);


### PR DESCRIPTION
Removes the 3 minute time window from Cabana.

Previously the system would switch between 3 minute windows, expressing them as an array with 2 values such as `[0,2]`. Every time this window would change, it would throw away all data and start new workers.

Now, instead it tracks both a "currentPart" and "currentParts" which keeps track of a 3 minute window as well as which part is currently playing (the middle one except for at the start and end). It filters out messages outside of the current window on window change, and it tracks which workers are currently running to prevent overlapping data. It also now cancels old workers so that they stop running when their data is going to be ignored.

A notable drawback is that you have less granular control over the time, since the bar is no longer zoomed in to 3 minutes, and also you can't loop over a segment anymore.

I still need to test streaming data in through a panda, fix a couple bugs, clean up some logs / test code, and fix up the ui a little bit