### PR TITLE
Signed URLs for shared rlog access

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://community.comma.ai/cabana",
   "dependencies": {
-    "@commaai/comma-api": "^1.1.4",
+    "@commaai/comma-api": "1.1.6",
     "@commaai/hls.js": "^0.12.2",
     "@commaai/log_reader": "^0.3.1",
     "@commaai/my-comma-auth": "^1.1.0",

--- a/src/api/rlog.js
+++ b/src/api/rlog.js
@@ -15,28 +15,9 @@ function ensureInit() {
   return initPromise;
 }
 
-export async function getLogURLList(routeName) {
-  if (urlStore[routeName]) {
-    return urlStore[routeName];
-  }
-  await ensureInit();
-
-  var data = await RawDataApi.getLogUrls(routeName);
-
-  urlStore[routeName] = data;
-
-  setTimeout(function() {
-    delete urlStore[routeName];
-  }, 1000 * 60 * 45); // expires in 1h, lets reset in 45m
-
-  return urlStore[routeName];
-}
-
-export async function getLogPart(routeName, part) {
+export async function getLogPart(logUrl) {
   return new Promise(async function(resolve, reject) {
-    var logUrls = await getLogURLList(routeName);
-
-    request(logUrls[part], function(err, res) {
+    request(logUrl, function(err, res) {
       if (err) {
         return reject(err);
       }

--- a/src/components/Meta.js
+++ b/src/components/Meta.js
@@ -3,9 +3,7 @@ import cx from "classnames";
 import PropTypes from "prop-types";
 import Clipboard from "clipboard";
 
-import { modifyQueryParameters } from "../utils/url";
 import MessageBytes from "./MessageBytes";
-import { GITHUB_AUTH_TOKEN_KEY } from "../config";
 const { ckmeans } = require("simple-statistics");
 
 export default class Meta extends Component {
@@ -340,17 +338,6 @@ export default class Meta extends Component {
     );
   }
 
-  shareUrl() {
-    const add = {
-      max: this.props.route.proclog,
-      url: this.props.route.url
-    };
-    const remove = [GITHUB_AUTH_TOKEN_KEY]; // don't share github access
-    const shareUrl = modifyQueryParameters({ add, remove });
-
-    return shareUrl;
-  }
-
   saveable() {
     try {
       // eslint-disable-next-line
@@ -386,16 +373,16 @@ export default class Meta extends Component {
                 <button onClick={this.props.saveLog}>Save Log</button>
               </div>
             )}
-            {this.props.route ? (
+            {this.props.shareUrl ? (
               <div
                 className="cabana-meta-header-action special-wide"
-                data-clipboard-text={this.shareUrl()}
+                data-clipboard-text={this.props.shareUrl}
                 data-clipboard-action="copy"
                 ref={ref => (ref ? new Clipboard(ref) : null)}
               >
                 <a
                   className="button"
-                  href={this.shareUrl()}
+                  href={this.props.shareUrl}
                   onClick={e => e.preventDefault()}
                 >
                   Copy Share Link

--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,24 @@ if (routeFullName) {
   persistedDbc = fetchPersistedDbc(routeFullName);
 
   let max = getUrlParameter("max"),
-    url = getUrlParameter("url");
+    url = getUrlParameter("url"),
+    exp = getUrlParameter("exp"),
+    sig = getUrlParameter("sig");
+
   if (max) {
     props.max = Number(max);
   }
   if (url) {
     props.url = url;
   }
-  props.isShare = max && url;
+  if (exp) {
+    props.exp = exp;
+  }
+  if (sig) {
+    props.sig = sig;
+  }
+  props.isLegacyShare = max && url && !exp && !sig;
+  props.isShare = max && url && exp && sig;
 } else if (getUrlParameter("demo")) {
   props.max = 12;
   props.url =

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -16,7 +16,7 @@ export function getUrlParameter(name) {
     : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
-export function modifyQueryParameters({ add, remove }) {
+export function modifyQueryParameters({ add, remove = [] }) {
   var regex = new RegExp("[\\?&]([^&#]+)=([^&#]*)");
   var results = regex.exec(location.search);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,20 +17,20 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@commaai/comma-api@^1.0.0":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@commaai/comma-api/-/comma-api-1.0.12.tgz#aa2be678dd0cdcf5102602e011051eda354853d6"
-  integrity sha512-AWwKaQzgQt6oyOP0lvMqy5/7rMQbKIVwTYX5MJnBFOVOgHrGmzxhPk8Bsi+5GpSA1qSFbnzoMvQ95QFC5teJhw==
+"@commaai/comma-api@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@commaai/comma-api/-/comma-api-1.1.6.tgz#be486443a8d8843c74a811cdd406b85694b5d526"
+  integrity sha512-LWglx5+GiQN4uhdBUjTJ3hsHxy0/tFVwZrIFKLSwwFyclQWizriHOE4IxKkGLudyQ/KgOL+bLljA+z/huEXW4w==
   dependencies:
     babel-runtime "^6.26.0"
     config-request "^0.5.1"
     joi-browser "^13.4.0"
     querystringify "^2.1.1"
 
-"@commaai/comma-api@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@commaai/comma-api/-/comma-api-1.1.4.tgz#75f727bfa43f6f446a341d1f9154f15334cfb79e"
-  integrity sha512-S25QY2OwO1aO5HKtvJQUnCwDsfBhgj7+SANZG99kHvxfFxOwWzT/GcV7G/xEtEJ06OsJ+Ih8XoUFm7IxNc1bwA==
+"@commaai/comma-api@^1.0.0":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@commaai/comma-api/-/comma-api-1.0.12.tgz#aa2be678dd0cdcf5102602e011051eda354853d6"
+  integrity sha512-AWwKaQzgQt6oyOP0lvMqy5/7rMQbKIVwTYX5MJnBFOVOgHrGmzxhPk8Bsi+5GpSA1qSFbnzoMvQ95QFC5teJhw==
   dependencies:
     babel-runtime "^6.26.0"
     config-request "^0.5.1"


### PR DESCRIPTION
Share links now contain a share signature in query parameters 'exp' and 'sig'. The route log_urls API  now accepts those parameters.

- CAN outputs no longer used for signed share links
- Support for existing share links is preserved