### PR TITLE
Revert Graph Interpolation back to Natural

### DIFF
--- a/src/vega/CanPlot.js
+++ b/src/vega/CanPlot.js
@@ -269,7 +269,7 @@ export default {
             "interactive": true,
             "encode": {
               "update": {
-                "interpolate": "cardinal",
+                "value": "natural",
                 "tension": 0,
                 "x": {
                   "scale": "xrelscale",


### PR DESCRIPTION
Cardinal graph interpolation causes headaches when you're trying to spot step changes. You are forced to have to hover over the plot to spot a intermediary jump between two linear points. Otherwise it appears as a smooth change and causes confusion when figuring out the message profile.

Natural:
![Screen Shot 2019-11-29 at 2 41 58 PM](https://user-images.githubusercontent.com/33460783/69894442-316ae300-1363-11ea-8447-0bbfd07e43ae.png)

Cardinal:
![Screen Shot 2019-11-29 at 2 18 01 PM](https://user-images.githubusercontent.com/33460783/69894446-3a5bb480-1363-11ea-9f53-c74115dabd52.png)



