### PR TITLE
Add CarControl actuators and RadarState leads for longitudinal testing

### DIFF
--- a/src/models/can/logSignals.js
+++ b/src/models/can/logSignals.js
@@ -54,6 +54,47 @@ export const controls = {
   })
 };
 
+export const actuators = {
+  Steer: shortSignal({
+    index: 0,
+    factor: 0.001
+  }),
+  SteerAngle: shortSignal({
+    index: 1,
+    factor: 0.001
+  }),
+  Brake: shortSignal({
+    index: 2,
+    factor: 0.001
+  }),
+  Gas: shortSignal({
+    index: 3,
+    factor: 0.001
+  })
+};
+
+export const leadOne = {
+  DRel: shortSignal({
+    index: 0,
+    factor: 0.001
+  }),
+  VRel: shortSignal({
+    index: 1,
+    factor: 0.001
+  }),
+};
+
+export const leadTwo = {
+  DRel: shortSignal({
+    index: 0,
+    factor: 0.001
+  }),
+  VRel: shortSignal({
+    index: 1,
+    factor: 0.001
+  }),
+};
+
 export const flags = {
   LeftBlinker: boolSignal({
     index: 0
@@ -196,6 +237,9 @@ export const signalMap = {
   'CarState:Ego': ego,
   'CarState:Controls': controls,
   'CarState:Flags': flags,
+  'CarControl:Actuators': actuators,
+  'RadarState:LeadOne': leadOne,
+  'RadarState:LeadTwo': leadTwo,
   'UbloxGnss:MeasurementReport': ubloxGnss,
   'Health:Data': health,
   'Thermal:CPU': thermalCPU,

--- a/src/workers/rlog-downloader.worker.js
+++ b/src/workers/rlog-downloader.worker.js
@@ -14,6 +14,9 @@ import {
   getEgoData,
   getCarStateControls,
   getWheelSpeeds,
+  getCarControlActuators,
+  getRadarStateLeadOne,
+  getRadarStateLeadTwo,
   getThermalFreeSpace,
   getThermalData,
   getThermalCPU,
@@ -204,6 +207,31 @@ async function loadData(entry) {
         entry,
         monoTime,
         partial(getWheelSpeeds, msg.CarState)
+      );
+    } else if ('CarControl' in msg) {
+      const monoTime = msg.LogMonoTime / 1000000000;
+       insertEventData(
+        'CarControl',
+        'Actuators',
+        entry,
+        monoTime,
+        partial(getCarControlActuators, msg.CarControl)
+      );
+    } else if ('RadarState' in msg) {
+      const monoTime = msg.LogMonoTime / 1000000000;
+       insertEventData(
+        'RadarState',
+        'LeadOne',
+        entry,
+        monoTime,
+        partial(getRadarStateLeadOne, msg.RadarState)
+      );
+       insertEventData(
+        'RadarState',
+        'LeadTwo',
+        entry,
+        monoTime,
+        partial(getRadarStateLeadTwo, msg.RadarState)
       );
     } else if ('UbloxGnss' in msg) {
       const monoTime = msg.LogMonoTime / 1000000000;

--- a/src/workers/rlog-utils.js
+++ b/src/workers/rlog-utils.js
@@ -168,6 +168,23 @@ export function getWheelSpeeds(state) {
     .concat(signedShortToByteArray(state.WheelSpeeds.Rr * 100));
 }
 
+export function getCarControlActuators(state) {
+  return signedShortToByteArray(state.Actuators.Steer * 1000)
+    .concat(signedShortToByteArray(state.Actuators.SteerAngle * 1000))
+    .concat(signedShortToByteArray(state.Actuators.Brake * 1000))
+    .concat(signedShortToByteArray(state.Actuators.Gas * 1000));
+}
+
+export function getRadarStateLeadOne(state) {
+  return signedShortToByteArray(state.LeadOne.DRel * 1000)
+    .concat(signedShortToByteArray(state.LeadOne.VRel * 1000));
+}
+
+export function getRadarStateLeadTwo(state) {
+  return signedShortToByteArray(state.LeadTwo.DRel * 1000)
+    .concat(signedShortToByteArray(state.LeadTwo.VRel * 1000));
+}
+
 export function getThermalFreeSpace(state) {
   return longToByteArray(state.FreeSpace * 1000000000);
 }


### PR DESCRIPTION
Added actuators and leads signals from log which would be useful for testing and development of longitudinal control. Tested and working using cabana demo