### PR TITLE
Fixes issue #31

### DIFF
--- a/src/components/MessageBytes.js
+++ b/src/components/MessageBytes.js
@@ -27,7 +27,9 @@ export default class MessageBytes extends Component {
       const curLastEntry = this.props.message.entries[
         this.props.message.entries.length - 1
       ];
-
+      if ( (curLastEntry === undefined) || ( nextLastEntry === undefined) ) {
+        return false
+      }
       return nextLastEntry.hexData !== curLastEntry.hexData;
     }
     return nextProps.seekTime !== this.props.seekTime;


### PR DESCRIPTION
Probably not the correct solution but it stops the error messages [in this issue](https://github.com/commaai/cabana/issues/31). I would like someone from the team to review my solution and make sure that it doesn't cause issues. Perhaps it is an error in the first place that either of the values of `curLastEntry` or `nextLastEntry` are undefined at all. I am not sure, but I just wanted cabana to work instead of throw error for the Panda I recently purchased to decode my Smart 4two 2014 CAN messages. It seemed like nobody responded at all to the issue from November 2019.

Here's the code I changed:

```{javascript}
shouldComponentUpdate(nextProps, nextState) {
    if (nextProps.live) {
      const nextLastEntry = nextProps.message.entries[nextProps.message.entries.length - 1];
      const curLastEntry = this.props.message.entries[
        this.props.message.entries.length - 1
      ];
      if ( (curLastEntry === undefined) || ( nextLastEntry === undefined) ) { // Just return false if you can't access so it doesn't
        return false  // throw an error and the app doesn't crash
      }
      return nextLastEntry.hexData !== curLastEntry.hexData;
    }
    return nextProps.seekTime !== this.props.seekTime;
  }
```

Just hoping that this prompts the team to fix some bugs in cabana, it's a great software but needs some attention. I don't think this code is the right fix but for some of us, it's better than nothing.