### PR TITLE
Fix react app documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ brew install libusb
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app) v1.x, then upgraded to `react-scripts` v3.x and use [craco](http://npm.im/@craco/craco) to customize it.
 
-You can read the create react app [documentation here](https://create-react-app.dev/docs/)
+You can read the create react app [documentation here](https://create-react-app.dev/docs/getting-started)
 
 We use craco to easily add [worker-loader](https://npm.im/worker-loader).
 


### PR DESCRIPTION
The old link showed a Page Not Found

![image](https://user-images.githubusercontent.com/4614400/129273073-4eba3a20-ed80-4c3a-9c56-aa52c2a41b3d.png)
