### PR TITLE
Fix setting comment on undefined msgs

### DIFF
--- a/src/models/can/dbc.js
+++ b/src/models/can/dbc.js
@@ -451,6 +451,12 @@ export default class DBC {
         let [messageId, comment] = matches.slice(1);
         messageId = parseInt(messageId, 10);
         const msg = messages.get(messageId);
+        if (msg === undefined) {
+          warnings.push(
+            `failed to find message to add comment to, msg id: ${messageId}`
+          );
+          continue;
+        }
         msg.comment = comment;
 
         if (hasFollowUp) {


### PR DESCRIPTION
This fixes a DBC parsing bug when there's a comment defined on an unknown messageId. See for example the `tesla_radar.dbc` in opendbc. 